### PR TITLE
Fix: Replace deprecated ActionUpdateThread.OLD_EDT with EDT

### DIFF
--- a/src/main/kotlin/com/werfad/Actions.kt
+++ b/src/main/kotlin/com/werfad/Actions.kt
@@ -1,5 +1,6 @@
 package com.werfad
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.project.DumbAwareAction
@@ -12,6 +13,10 @@ abstract class BaseAction : DumbAwareAction() {
 
     override fun actionPerformed(e: AnActionEvent) {
         JumpHandler.start(getMode(), e)
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.EDT
     }
 
     abstract fun getMode(): Int


### PR DESCRIPTION
- Overriding the method getActionUpdateThread() to return ActionUpdateThread.EDT which should be used for the UI related actions.