### PR TITLE
Update pluginUntilBuild to 242.* to support newer IDE versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 1.0.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223
-pluginUntilBuild = 233.*
+pluginUntilBuild = 242.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC


### PR DESCRIPTION
There’s an issue when trying to install KJump v1.0.2 on newer IDE versions. The IDE blocks installation with a compatibility error mentioned in [#51](https://github.com/a690700752/KJump/issues/51). Error message varies based on the IDE and its version.

I ran  `gradle runPluginVerifier` after updating the version and saw no issues.

Tested the updated untiBuild config with my IDEA Ultimate version 2024.2.3 and was able to install the latest Kjump version.

**Note:**  
Build `242.*` of the IDE [requires **Java 21**](https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html) for developing and testing the  plugin. Is this fine or should I change it to some other version?